### PR TITLE
Pattern attr not allowing special characters added

### DIFF
--- a/public/views/Rooms.svelte
+++ b/public/views/Rooms.svelte
@@ -103,6 +103,7 @@
       maxlength="10"
       required
       placeholder="Room name"
+      pattern="[A-Za-z0-9]+"
       bind:value={newRoomModal.roomName}
       style="margin-top: 0"
     >


### PR DESCRIPTION
## Description
While joining a new room, the room name must not contain characters such as #, ?, & ... which have a special meaning in a URL. When these characters are used, the app stops working as expected.

## Motivation and context
closes #38 

## Types of changes
Regex pattern added, so when the user try to type special character, a tooltip will show and the room's name will not be submitted yet.

## What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **[CONTRIBUTING] or [README]** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes. **(N/A)**
- [x] If my change requires a change to the documentation, I have updated it accordingly.
