### PR TITLE
Add overflow scroll for desktop

### DIFF
--- a/public/scss/app/_desktop.scss
+++ b/public/scss/app/_desktop.scss
@@ -39,6 +39,16 @@ body {
 
     &.card {
       width: 100%;
+
+      &.files {
+        height: 60vh;
+
+        ul.files {
+          margin: 0;
+          max-height: calc(100% - 50px);
+          overflow-y: scroll;
+        }
+      }
     }
 
   }

--- a/public/scss/app/_desktop.scss
+++ b/public/scss/app/_desktop.scss
@@ -46,7 +46,7 @@ body {
         ul.files {
           margin: 0;
           max-height: calc(100% - 50px);
-          overflow-y: scroll;
+          overflow-y: auto;
         }
       }
     }

--- a/public/scss/app/_desktop.scss
+++ b/public/scss/app/_desktop.scss
@@ -40,14 +40,10 @@ body {
     &.card {
       width: 100%;
 
-      &.files {
-        height: 60vh;
-
-        ul.files {
-          margin: 0;
-          max-height: calc(100% - 50px);
-          overflow-y: auto;
-        }
+      ul.files {
+        margin: 0;
+        max-height: calc(60vh - 50px);
+        overflow-y: auto;
       }
     }
 

--- a/public/scss/app/_desktop.scss
+++ b/public/scss/app/_desktop.scss
@@ -40,10 +40,12 @@ body {
     &.card {
       width: 100%;
 
-      ul.files {
-        margin: 0;
-        max-height: calc(60vh - 50px);
-        overflow-y: auto;
+      &.files {
+        ul.files {
+          margin: 0;
+          max-height: calc(60vh - 50px);
+          overflow-y: auto;
+        }
       }
     }
 


### PR DESCRIPTION
Added overflow auto for files.
The max-height is 60vh-50px since the header's height is 50px and the scrollable area is without the header. 60vh cames from parent container's height