### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:13-alpine AS base
+WORKDIR /app
+
+FROM base AS build
+COPY . .
+RUN npm install && \
+    npm run build
+
+FROM base AS release
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/index.js ./
+EXPOSE 3030
+CMD ["node", "index.js"]


### PR DESCRIPTION
I wrote a simple but working Dockerfile to pack blaze into an docker image.

You may need to register an account on hub.docker.com and setup something like auto build.

Hope this PR can save some time for others when deploying blaze on their server.