### PR TITLE
Fix social link preview

### DIFF
--- a/client/src/template.html
+++ b/client/src/template.html
@@ -11,17 +11,17 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="description" content="Blaze is a peer-to-peer file sharing web app runs on any operating system! Blaze can be used for fast and easy file transfer between two or more peers at the same time.">
 
-    <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website">
-    <meta property="og:description" content="Blaze is a peer-to-peer file sharing web app runs on any operating system! Blaze can be used for fast and easy file transfer between two or more peers at the same time.">
-    <meta property="og:image" content="./assets/images/site-preview.jpg">
-    <meta property="og:url" content="https://blaze.now.sh/">
-    <meta property="og:title" content="Blaze | File sharing web app ⚡">
-
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:description" content="Blaze is a peer-to-peer file sharing web app runs on any operating system! Blaze can be used for fast and easy file transfer between two or more peers at the same time.">
-    <meta property="twitter:image" content="./assets/images/site-preview.jpg">
+    <meta property="twitter:image" content="https://blaze.now.sh/assets/images/site-preview.jpg">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:description" content="Blaze is a peer-to-peer file sharing web app runs on any operating system! Blaze can be used for fast and easy file transfer between two or more peers at the same time.">
+    <meta property="og:image" content="https://blaze.now.sh/assets/images/site-preview.jpg">
+    <meta property="og:url" content="https://blaze.now.sh/">
+    <meta property="og:title" content="Blaze | File sharing web app ⚡">
 
     <link rel="preload" href="https://fonts.googleapis.com/css?family=Jost:500,600&display=swap" as="style">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Jost:500,600&display=swap">  

--- a/client/src/template.html
+++ b/client/src/template.html
@@ -14,12 +14,14 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:description" content="Blaze is a peer-to-peer file sharing web app runs on any operating system! Blaze can be used for fast and easy file transfer between two or more peers at the same time.">
-    <meta property="og:image" content="assets/images/site-preview.jpg">
+    <meta property="og:image" content="./assets/images/site-preview.jpg">
+    <meta property="og:url" content="https://blaze.now.sh/">
+    <meta property="og:title" content="Blaze | File sharing web app ⚡">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:description" content="Blaze is a peer-to-peer file sharing web app runs on any operating system! Blaze can be used for fast and easy file transfer between two or more peers at the same time.">
-    <meta property="twitter:image" content="assets/images/site-preview.jpg">
+    <meta property="twitter:image" content="./assets/images/site-preview.jpg">
 
     <link rel="preload" href="https://fonts.googleapis.com/css?family=Jost:500,600&display=swap" as="style">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Jost:500,600&display=swap">  


### PR DESCRIPTION
Actually the bug is False-positive. I cross checked with [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fblaze.now.sh%2F) and [LinkedIn Post Inpector](https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fblaze.now.sh%2F). 
Both the Results shows the Site Preview Image. 

The real bug relies not with Blaze but with the **https://socialsharepreview.com/** , only there the Site Image is not showing. All other official debuggers show the site preview image.

**What I added?**

- [x] While debugging Facebook Sharing meta tags. It seems `og:title` and `og:url `are required so I added those.

**This closes** #92 