### PR TITLE
Feature: Add logic for closing modal with escape key  #94

### DIFF
--- a/client/src/components/Modal/Modal.js
+++ b/client/src/components/Modal/Modal.js
@@ -12,18 +12,19 @@ function Modal({ isClosable, isOpen, onClose, children }) {
   }, [ isOpen ]);
 
   useEffect(() => {
-    if(isClosable){
+    if (isClosable){
       const handleEsc = (event) => {
-          if (event.key === "Escape"||event.keyCode === 27 || event.which===27) {
-            onClose();
-          }
+        if (event.key === "Escape" || event.keyCode === 27 || event.which === 27) {
+          onClose(event);
+        }
       };
+
       window.addEventListener('keydown', handleEsc);
       return () => {
         window.removeEventListener('keydown', handleEsc);
       };
     }
-  }, []);
+  }, [ isClosable, onClose ]);
 
   return createPortal(
     <div class="modal-wrapper" style={isOpen ? { opacity: 1, visibility: 'visible' } : {}}>

--- a/client/src/components/Modal/Modal.js
+++ b/client/src/components/Modal/Modal.js
@@ -10,7 +10,20 @@ function Modal({ isClosable, isOpen, onClose, children }) {
   useEffect(() => {
     document.body.classList.toggle('no-bg-image', isOpen);
   }, [ isOpen ]);
-  
+
+  useEffect(() => {
+
+    const handleEsc = (event) => {
+        if (event.key === "Escape"||event.keyCode === 27 || event.which===27) {
+          onClose();
+        }
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, []);
+
   return createPortal(
     <div class="modal-wrapper" style={isOpen ? { opacity: 1, visibility: 'visible' } : {}}>
 

--- a/client/src/components/Modal/Modal.js
+++ b/client/src/components/Modal/Modal.js
@@ -12,16 +12,17 @@ function Modal({ isClosable, isOpen, onClose, children }) {
   }, [ isOpen ]);
 
   useEffect(() => {
-
-    const handleEsc = (event) => {
-        if (event.key === "Escape"||event.keyCode === 27 || event.which===27) {
-          onClose();
-        }
-    };
-    window.addEventListener('keydown', handleEsc);
-    return () => {
-      window.removeEventListener('keydown', handleEsc);
-    };
+    if(isClosable){
+      const handleEsc = (event) => {
+          if (event.key === "Escape"||event.keyCode === 27 || event.which===27) {
+            onClose();
+          }
+      };
+      window.addEventListener('keydown', handleEsc);
+      return () => {
+        window.removeEventListener('keydown', handleEsc);
+      };
+    }
   }, []);
 
   return createPortal(


### PR DESCRIPTION
This commit enhances  closing modal feature with the escape key. 
 Closing button in the ` <Modal />` component is showing only if `isClosable` props is true. 
