### PR TITLE
Add DigitalOcean App platform template and deploy button

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,15 @@
+spec:
+  name: blaze
+  services:
+  - name: web
+    git:
+      branch: master
+      repo_clone_url: https://github.com/blenderskool/blaze.git
+    http_port: 80
+    dockerfile_path: ./Dockerfile
+    envs:
+    - key: PORT
+      scope: RUN_AND_BUILD_TIME
+      value: "80"
+    routes:
+    - path: /

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Read more about how Blaze works at a basic level in this [Medium article](https:
 
 ### Deploy your own instance of Blaze
 <p>
+  <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/blenderskool/blaze/tree/master&refcode=ddb2a965377c">
+    <img src="https://www.deploytodo.com/do-btn-blue.svg" alt="Deploy to DO" width="200">
+  </a>
   <a href="https://heroku.com/deploy?template=https://github.com/blenderskool/blaze/tree/master">
     <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
   </a>


### PR DESCRIPTION
Deploying Blaze to DigitalOcean is now easier with the App platform template and one-click deploy button on the README! 🐋 