### PR TITLE
fix: docker-compose now

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: ./server/Dockerfile
     environment:
-      TRUST_PROXY: true
+      TRUST_PROXY: 1
     ports:
       - 3030:3030
 


### PR DESCRIPTION
# As of now docker-compose "TRUST_PROXY" requires numbers instead of booleans

- docker-compose version 1.29.2, build unknown
- Linux instance-test 5.15.0-1029-oracle 35-Ubuntu SMP Tue Jan 24 15:17:52 UTC 2023 x86_64 x86_64 x86_64 GNU/Lin

error: 👇🏻
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.blaze-server.environment.TRUST_PROXY contains true, which is an invalid type, it should be a string, number, or a null
```