### PR TITLE
Displayed error modals when connection to server fails

### DIFF
--- a/client/src/routes/App/FileTransfer/FileTransfer.js
+++ b/client/src/routes/App/FileTransfer/FileTransfer.js
@@ -452,7 +452,7 @@ class FileTransfer extends PureComponent {
           <>
             <h2>Connection Error!</h2>
             <p class="message">Unable to load QR code, try refreshing this page</p>
-            <button class="btn wide" onClick={this.handleNewRoom}>
+            <button class="btn wide" onClick={() => window.location.reload()}>
               Refresh page
             </button>
           </>

--- a/client/src/routes/App/FileTransfer/FileTransfer.js
+++ b/client/src/routes/App/FileTransfer/FileTransfer.js
@@ -256,6 +256,14 @@ class FileTransfer extends PureComponent {
       });
     });
 
+    socket.on('error', err => {
+      this.setState({
+        errorModal: {
+          isOpen: true,
+          type: err.reason || constants.ERR_CONN_CLOSED,
+        },
+      });
+    });
 
     this.clearReceiver = this.fileShare.receiveFiles({
       onMeta: (data) => {

--- a/client/src/routes/App/FileTransfer/FileTransfer.js
+++ b/client/src/routes/App/FileTransfer/FileTransfer.js
@@ -447,6 +447,16 @@ class FileTransfer extends PureComponent {
             </button>
           </>
         );
+      case constants.QR_CODE_LOAD_FAILED:
+        return (
+          <>
+            <h2>Connection Error!</h2>
+            <p class="message">Unable to load QR code, try refreshing this page</p>
+            <button class="btn wide" onClick={this.handleNewRoom}>
+              Refresh page
+            </button>
+          </>
+        );
       case constants.ERR_CONN_CLOSED:
       default:
         return (
@@ -595,14 +605,14 @@ class FileTransfer extends PureComponent {
               loading="lazy"
               alt={`QR code to join "${this.client.room}" room`}
               onError={() => {
-                this.toggleQRCodeModal(false);
-
                 this.setState({
                   errorModal: {
                     isOpen: true,
-                    type: constants.ERR_SAME_NAME
+                    type: constants.QR_CODE_LOAD_FAILED
                   },
                 });
+
+                this.toggleQRCodeModal(false);
               }}
             />
 

--- a/client/src/routes/App/FileTransfer/FileTransfer.js
+++ b/client/src/routes/App/FileTransfer/FileTransfer.js
@@ -594,6 +594,16 @@ class FileTransfer extends PureComponent {
               src={`${urls.SERVER_HOST}/rooms/qrcode?room=${this.props.room}`}
               loading="lazy"
               alt={`QR code to join "${this.client.room}" room`}
+              onError={() => {
+                this.toggleQRCodeModal(false);
+
+                this.setState({
+                  errorModal: {
+                    isOpen: true,
+                    type: constants.ERR_SAME_NAME
+                  },
+                });
+              }}
             />
 
             <button class="btn outlined wide" onClick={() => this.toggleQRCodeModal(false)}>

--- a/client/src/routes/App/FileTransfer/FileTransfer.js
+++ b/client/src/routes/App/FileTransfer/FileTransfer.js
@@ -447,16 +447,6 @@ class FileTransfer extends PureComponent {
             </button>
           </>
         );
-      case constants.QR_CODE_LOAD_FAILED:
-        return (
-          <>
-            <h2>Connection Error!</h2>
-            <p class="message">Unable to load QR code, try refreshing this page</p>
-            <button class="btn wide" onClick={() => window.location.reload()}>
-              Refresh page
-            </button>
-          </>
-        );
       case constants.ERR_CONN_CLOSED:
       default:
         return (
@@ -598,24 +588,28 @@ class FileTransfer extends PureComponent {
         <Modal isOpen={showQRCodeModal} onClose={() => this.toggleQRCodeModal(false)}>
           <div class="qrcode-modal">
             <h2>Room QR code</h2>
-            <p>Scan this QR code to join "{this.client.room}" file sharing room.</p>
-
-            <img
-              src={`${urls.SERVER_HOST}/rooms/qrcode?room=${this.props.room}`}
-              loading="lazy"
-              alt={`QR code to join "${this.client.room}" room`}
-              onError={() => {
-                this.setState({
-                  errorModal: {
-                    isOpen: true,
-                    type: constants.QR_CODE_LOAD_FAILED
-                  },
-                });
-
-                this.toggleQRCodeModal(false);
-              }}
-            />
-
+            {
+              this.state.errorModal.type === constants.QR_CODE_LOAD_FAILED ? (
+                <p>Could not load QR code</p>
+              ) : (
+                <>
+                  <p>Scan this QR code to join "{this.client.room}" file sharing room.</p>
+                  <img
+                    src={`${urls.SERVER_HOST}/rooms/qrcode?room=${this.props.room}`}
+                    loading="lazy"
+                    alt={`QR code to join "${this.client.room}" room`}
+                    onError={() => {
+                      this.setState({
+                        errorModal: {
+                          isOpen: true,
+                          type: constants.QR_CODE_LOAD_FAILED
+                        },
+                      });
+                    }}
+                  />
+                </>
+              )
+            }
             <button class="btn outlined wide" onClick={() => this.toggleQRCodeModal(false)}>
               Close popup
             </button>

--- a/common/constants.js
+++ b/common/constants.js
@@ -12,6 +12,7 @@ export default {
   ERR_SAME_NAME: 'ERR_SAME_NAME',
   ERR_CONN_CLOSED: 'ERR_CONN_CLOSED',
   ERR_LARGE_FILE: 'ERR_LARGE_FILE',
+  QR_CODE_LOAD_FAILED: 'QR_CODE_LOAD_FAILED',
 
   /* service worker features related */
   SW_LOAD_FILES: 'sw-load-files',


### PR DESCRIPTION
## Description

Closes #172 

Using the already existing modal component, I have covered two edge cases when an error happens, and nothing is displayed to the user.

### First case
If the user goes to their room and clicks on the QR code button quickly, before the `Connection closed` modal pops up, they are presented with the modal that displays the QR code, with a broken image of the QR code, since there's no connection to the server. I simply added an onError listener to the `img` element, that now clearly displays an error modal with information to the user, i.e.:

![image](https://github.com/user-attachments/assets/cdb33617-88ba-41dd-a9f4-faac0382b8c9)

instead of just:

![image](https://github.com/user-attachments/assets/b52f873a-84cb-4959-965b-d2e000b8c833)


### Second case
If the connection to the server is failing, we are unable to load the local peers, this failure is not being displayed to the user in any way. A simple modal is now being displayed when the peers are failing to load to the user, asking them to check their internet connection! i.e.: 

![image](https://github.com/user-attachments/assets/cd0c2acd-4f09-48c1-910e-e392abc5fb12)

Whereas before, while peers fail to load, no errors were being displayed at all.

## Testing

- Test by running the `client` without the `server`, go to `localhost:8080/app`, you should have an error modal pop up telling you what the issue is.

- Test by running the `client` without the `server`, go to `localhost:8080/app`, and try to go to the `local network room` really quick before the error modal pops up, and continue to quickly click on the `QR` button, that displays the modal which displays the `QR` code. You should not get an error message when it fails to retrieve the proper `QR` code from the server.


Please let me know if there are any suggestion or requested changes, I'd be glad to apply them! 



